### PR TITLE
Updated GO syntax

### DIFF
--- a/docs-2.0/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0/3.ngql-guide/7.general-query-statements/3.go.md
@@ -18,7 +18,7 @@ OVER <edge_type_list> [{REVERSELY | BIDIRECT}]
 
 GO [[<M> TO] <N> STEPS ] FROM <vertex_list>
 OVER <edge_type_list> [{REVERSELY | BIDIRECT}]
-[ WHERE <expression> [ {AND | OR} expression ...]) ]
+[ WHERE <condition> ]
 [| GROUP BY {col_name | expr | position} YIELD <col_name>]
 
 <vertex_list> ::=
@@ -42,7 +42,7 @@ OVER <edge_type_list> [{REVERSELY | BIDIRECT}]
 
 - `REVERSELY | BIDIRECT`：默认情况下检索的是`<vertex_list>`的出边，`REVERSELY`表示反向，即检索入边，`BIDIRECT`表示双向，即检索出边和入边。
 
-- `WHERE <expression>`：指定遍历的过滤条件。您可以在起始点、目的点和边使用`WHERE`子句，还可以结合`AND`、`OR`、`NOT`一起使用。详情请参见[WHERE](../8.clauses-and-options/where.md)。
+- `WHERE <condition>`：指定遍历的过滤条件。您可以在起始点、目的点和边使用`WHERE`子句，还可以结合`AND`、`OR`、`NOT`、`XOR`一起使用。详情请参见[WHERE](../8.clauses-and-options/where.md)。
 
     >**说明**：遍历多个边类型时，`WHERE`子句有一些限制。例如不支持`WHERE edge1.prop1 > edge2.prop2`。
 

--- a/docs-2.0/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0/3.ngql-guide/7.general-query-statements/3.go.md
@@ -18,7 +18,7 @@ OVER <edge_type_list> [{REVERSELY | BIDIRECT}]
 
 GO [[<M> TO] <N> STEPS ] FROM <vertex_list>
 OVER <edge_type_list> [{REVERSELY | BIDIRECT}]
-[ WHERE <condition> ]
+[ WHERE <conditions> ]
 [| GROUP BY {col_name | expr | position} YIELD <col_name>]
 
 <vertex_list> ::=
@@ -42,7 +42,7 @@ OVER <edge_type_list> [{REVERSELY | BIDIRECT}]
 
 - `REVERSELY | BIDIRECT`：默认情况下检索的是`<vertex_list>`的出边，`REVERSELY`表示反向，即检索入边，`BIDIRECT`表示双向，即检索出边和入边。
 
-- `WHERE <condition>`：指定遍历的过滤条件。您可以在起始点、目的点和边使用`WHERE`子句，还可以结合`AND`、`OR`、`NOT`、`XOR`一起使用。详情请参见[WHERE](../8.clauses-and-options/where.md)。
+- `WHERE <conditions>`：指定遍历的过滤条件。您可以在起始点、目的点和边使用`WHERE`子句，还可以结合`AND`、`OR`、`NOT`、`XOR`一起使用。详情请参见[WHERE](../8.clauses-and-options/where.md)。
 
     >**说明**：遍历多个边类型时，`WHERE`子句有一些限制。例如不支持`WHERE edge1.prop1 > edge2.prop2`。
 

--- a/docs-2.0/3.ngql-guide/8.clauses-and-options/where.md
+++ b/docs-2.0/3.ngql-guide/8.clauses-and-options/where.md
@@ -14,13 +14,6 @@
 
 - [过滤rank](#过滤rank)是原生nGQL功能。只支持在nGQL扩展的语句（例如`GO`和`LOOKUP`）中使用，因为openCypher中没有rank的概念。
 
-
-## 语法
-
-```ngql
-WHERE <expression> [ AND|OR|XOR <expression> ...]);
-```
-
 ## 基础用法
 
 ### 用布尔运算符定义条件

--- a/docs-2.0/3.ngql-guide/8.clauses-and-options/where.md
+++ b/docs-2.0/3.ngql-guide/8.clauses-and-options/where.md
@@ -10,7 +10,7 @@
 
 ## openCypher兼容性
 
-- 不支持在模式中使用[`WHERE`](where.md子句，例如`WHERE (v)-->(v2)`。
+- 不支持在模式中使用`WHERE`子句（TODO: planning），例如`WHERE (v)-->(v2)`。
 
 - [过滤rank](#过滤rank)是原生nGQL功能。只支持在nGQL扩展的语句（例如`GO`和`LOOKUP`）中使用，因为openCypher中没有rank的概念。
 

--- a/docs-2.0/3.ngql-guide/8.clauses-and-options/where.md
+++ b/docs-2.0/3.ngql-guide/8.clauses-and-options/where.md
@@ -10,7 +10,7 @@
 
 ## openCypher兼容性
 
-- 不支持在模式中使用`WHERE`子句（TODO: planning），例如`WHERE (v)-->(v2)`。
+- 不支持在模式中使用[`WHERE`](where.md子句，例如`WHERE (v)-->(v2)`。
 
 - [过滤rank](#过滤rank)是原生nGQL功能。只支持在nGQL扩展的语句（例如`GO`和`LOOKUP`）中使用，因为openCypher中没有rank的概念。
 


### PR DESCRIPTION
`WHERE` also supports `NOT`, but if we write all the Boolean operators  it in the syntax, it looks a bit complicated, like:
`WHERE [NOT] <condition> [{AND|OR|XOR} [NOT] <condition>]`.
Delete extra information to simplify the docs.