### PR TITLE
back-ticks fenced code blocks were indented (#366)

### DIFF
--- a/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
+++ b/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
@@ -61,90 +61,90 @@
 
 1. 安装依赖包。
 
-    - CentOS、RedHat、Fedora用户请执行如下命令：
+   - CentOS、RedHat、Fedora用户请执行如下命令：
 
-    ```bash
-    $ yum update
-    $ yum install -y make \
-                     m4 \
-                     git \
-                     wget \
-                     unzip \
-                     xz \
-                     readline-devel \
-                     ncurses-devel \
-                     zlib-devel \
-                     gcc \
-                     gcc-c++ \
-                     cmake \
-                     gettext \
-                     curl \
-                     redhat-lsb-core
-    // 仅CentOS 8+、RedHat 8+、Fedora需要安装libstdc++-static和libasan。
-    $ yum install -y libstdc++-static libasan
-    ```
+      ```bash
+      $ yum update
+      $ yum install -y make \
+                       m4 \
+                       git \
+                       wget \
+                       unzip \
+                       xz \
+                       readline-devel \
+                       ncurses-devel \
+                       zlib-devel \
+                       gcc \
+                       gcc-c++ \
+                       cmake \
+                       gettext \
+                       curl \
+                       redhat-lsb-core
+      // 仅CentOS 8+、RedHat 8+、Fedora需要安装libstdc++-static和libasan。
+      $ yum install -y libstdc++-static libasan
+      ```
 
-    - Debian和Ubuntu用户请执行如下命令：
+   - Debian和Ubuntu用户请执行如下命令：
 
-    ```bash
-    $ apt-get update
-    $ apt-get install -y make \
-                         m4 \
-                         git \
-                         wget \
-                         unzip \
-                         xz-utils \
-                         curl \
-                         lsb-core \
-                         build-essential \
-                         libreadline-dev \
-                         ncurses-dev \
-                         cmake \
-                         gettext
-    ```
+      ```bash
+      $ apt-get update
+      $ apt-get install -y make \
+                           m4 \
+                           git \
+                           wget \
+                           unzip \
+                           xz-utils \
+                           curl \
+                           lsb-core \
+                           build-essential \
+                           libreadline-dev \
+                           ncurses-dev \
+                           cmake \
+                           gettext
+      ```
 
 2. 检查主机上的GCC和CMake版本是否正确。版本信息请参见[软件要求](#_4)。
 
-    ```bash
-    $ g++ --version
-    $ cmake --version
-    ```
+   ```bash
+   $ g++ --version
+   $ cmake --version
+   ```
 
-    如果版本正确，您可以跳过本小节。如果不正确，请根据如下步骤安装：
+   如果版本正确，您可以跳过本小节。如果不正确，请根据如下步骤安装：
 
-    1. 克隆仓库`nebula-common`到主机。
+   1. 克隆仓库`nebula-common`到主机。
 
-    ```bash
-    $ git clone https://github.com/vesoft-inc/nebula-common.git
-    ```
+      ```bash
+      $ git clone https://github.com/vesoft-inc/nebula-common.git
+      ```
 
-    类似{{ nebula.release }}版本的Nebula Graph源码存储在特定的分支，您可以使用`--branch`或`-b`选项指定克隆的分支。例如指定{{ nebula.release }}，命令如下：
+      如需安装特定版本的Nebula Graph，使用`--branch`或`-b`选项指定相应的nebula-common分支。 例如，指定{{ nebula.release }}，命令如下：
 
-    ```bash
-    $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-common.git
-    ```
+      ```bash
+      $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-common.git
+      ```
 
-    2. 进入目录`nebula-common`。
+   2. 进入目录`nebula-common`。
 
-    ```bash
-    $ cd nebula-common
-    ```
+      ```bash
+      $ cd nebula-common
+      ```
 
-    3. 执行如下命令安装和启用GCC和CMake。
+   3. 执行如下命令安装和启用GCC和CMake。
 
-    ```bash
-    // 安装CMake。
-    $ ./third-party/install-cmake.sh cmake-install
+      ```bash
+      // 安装CMake。
+      $ ./third-party/install-cmake.sh cmake-install
 
-    // 启用CMake。
-    $ source cmake-install/bin/enable-cmake.sh
+      // 启用CMake。
+      $ source cmake-install/bin/enable-cmake.sh
 
-    // 安装GCC。安装到opt目录需要root权限，您也可以修改为其他目录。
-    $ sudo ./third-party/install-gcc.sh --prefix=/opt
+      // 安装GCC。安装到opt目录需要root权限，您也可以修改为其他目录。
+      $ sudo ./third-party/install-gcc.sh --prefix=/opt
 
-    // 启用GCC。
-    $ source /opt/vesoft/toolset/gcc/7.5.0/enable
-    ```
+      // 启用GCC。
+      $ source /opt/vesoft/toolset/gcc/7.5.0/enable
+      ```
 
 ## 测试环境运行Nebula Graph要求
 
@@ -232,13 +232,13 @@ storaged进程的数量不会影响图空间副本的数量。
 
 - 问题 1：为什么磁盘空间和内存都要乘以120%？
 
-    答：额外的20%用于缓冲。
+   答：额外的20%用于缓冲。
 
 - 问题 2：如何获取RocksDB实例数量？
 
-    答：在`etc`目录内查看配置文件`nebula-storaged.conf`，`--data_path`选项中的每个目录对应一个RocksDB实例，目录总数即是RocksDB实例数量。
+   答：在`etc`目录内查看配置文件`nebula-storaged.conf`，`--data_path`选项中的每个目录对应一个RocksDB实例，目录总数即是RocksDB实例数量。
 
-    >**说明**：您可以在配置文件`nebula-storaged.conf`中添加`--enable_partitioned_index_filter=true`来降低bloom过滤器占用的内存大小，但是在某些随机寻道（random-seek）的情况下，可能会降低读取性能。
+   >**说明**：您可以在配置文件`nebula-storaged.conf`中添加`--enable_partitioned_index_filter=true`来降低bloom过滤器占用的内存大小，但是在某些随机寻道（random-seek）的情况下，可能会降低读取性能。
 
 ## 关于存储设备
 

--- a/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
+++ b/docs-2.0/4.deployment-and-installation/1.resource-preparations.md
@@ -114,36 +114,37 @@
 
     1. 克隆仓库`nebula-common`到主机。
 
-        ```bash
-        $ git clone https://github.com/vesoft-inc/nebula-common.git
-        ```
+    ```bash
+    $ git clone https://github.com/vesoft-inc/nebula-common.git
+    ```
 
-        类似{{ nebula.release }}版本的Nebula Graph源码存储在特定的分支，您可以使用`--branch`或`-b`选项指定克隆的分支。例如指定{{ nebula.release }}，命令如下：
+    类似{{ nebula.release }}版本的Nebula Graph源码存储在特定的分支，您可以使用`--branch`或`-b`选项指定克隆的分支。例如指定{{ nebula.release }}，命令如下：
 
-        ```bash
-        $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-common.git
-        ```
+    ```bash
+    $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-common.git
+    ```
 
     2. 进入目录`nebula-common`。
 
-        ```bash
-        $ cd nebula-common
-        ```
+    ```bash
+    $ cd nebula-common
+    ```
 
     3. 执行如下命令安装和启用GCC和CMake。
 
-        ```bash
-        // 安装CMake。
-        $ ./third-party/install-cmake.sh cmake-install
+    ```bash
+    // 安装CMake。
+    $ ./third-party/install-cmake.sh cmake-install
 
-        // 启用CMake。
-        $ source cmake-install/bin/enable-cmake.sh
+    // 启用CMake。
+    $ source cmake-install/bin/enable-cmake.sh
 
-        // 安装GCC。安装到opt目录需要root权限，您也可以修改为其他目录。
-        $ sudo ./third-party/install-gcc.sh --prefix=/opt
+    // 安装GCC。安装到opt目录需要root权限，您也可以修改为其他目录。
+    $ sudo ./third-party/install-gcc.sh --prefix=/opt
 
-        // 启用GCC。
-        $ source /opt/vesoft/toolset/gcc/7.5.0/enable
+    // 启用GCC。
+    $ source /opt/vesoft/toolset/gcc/7.5.0/enable
+    ```
 
 ## 测试环境运行Nebula Graph要求
 

--- a/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
+++ b/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
@@ -12,70 +12,71 @@
 
 1. 克隆Nebula Graph源码到主机。
 
-    - 如果需要安装最新版本的开发代码，请执行如下命令下载`master`分支的源码：
+   - 如果需要安装最新版本的开发代码，请执行如下命令下载`master`分支的源码：
 
-    ```bash
-    $ git clone https://github.com/vesoft-inc/nebula-graph.git
-    ```
+      ```bash
+      $ git clone https://github.com/vesoft-inc/nebula-graph.git
+      ```
 
-    - 如果需要安装指定版本的Nebula Graph 2.x，请使用选项`--branch`指定分支。例如安装{{ nebula.release }} 发布版本，请执行如下命令：
+   - 如果需要安装指定版本的Nebula Graph 2.x，请使用选项`--branch`指定分支。例如安装{{ nebula.release }} 发布版本，请执行如下命令：
 
-    ```bash
-    $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-graph.git
-    ```
+      ```bash
+      $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-graph.git
+      ```
 
 2. 进入目录`nebula-graph`。
 
-    ```bash
-    $ cd nebula-graph
-    ```
+   ```bash
+   $ cd nebula-graph
+   ```
 
 3. 创建目录`build`并进入该目录。
 
-    ```bash
-    $ mkdir build && cd build
-    ```
+   ```bash
+   $ mkdir build && cd build
+   ```
 
 4. 使用CMake生成makefile文件。
 
-    >**说明**：
-    >
-    >- 默认安装路径为`/user/local/nebula`，如果需要修改路径，请在下方命令内增加参数`-DCMAKE_INSTALL_PREFIX=<installation_path>`。
-    >- 更多CMake参数说明，请参见[CMake参数](#cmake)。
+   >**说明**：
+   >
+   >- 默认安装路径为`/user/local/nebula`，如果需要修改路径，请在下方命令内增加参数`-DCMAKE_INSTALL_PREFIX=<installation_path>`。
+   >- 更多CMake参数说明，请参见[CMake参数](#cmake)。
 
-    - 如果您在第1步下载的是最新版本的开发代码，请执行如下命令：
+   - 如果您在第1步下载的是最新版本的开发代码，请执行如下命令：
 
-    ```bash
-    $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
-    ```
+      ```bash
+      $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
+      ```
 
-    - 如果您在第1步下载的是指定版本的Nebula Graph 2.x，请使用选项`-DNEBULA_COMMON_REPO_TAG`和`-DNEBULA_STORAGE_REPO_TAG`指定相同的[nebula-common](https://github.com/vesoft-inc/nebula-common)和[nebula-storage](https://github.com/vesoft-inc/nebula-storage)分支。例如安装{{ nebula.release }} GA版本，请执行如下命令：
+   - 如果您在第1步下载的是指定版本的Nebula Graph 2.x，请使用选项`-DNEBULA_COMMON_REPO_TAG`和`-DNEBULA_STORAGE_REPO_TAG`指定相同的[nebula-common](https://github.com/vesoft-inc/nebula-common)和[nebula-storage](https://github.com/vesoft-inc/nebula-storage)分支。例如安装{{ nebula.release }} GA版本，请执行如下命令：
 
-    ```bash
-    $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
-    -DNEBULA_COMMON_REPO_TAG=v{{ nebula.release }} -DNEBULA_STORAGE_REPO_TAG=v{{ nebula.release }} ..
-    ```
+      ```bash
+      $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
+      -DNEBULA_COMMON_REPO_TAG=v{{ nebula.release }} -DNEBULA_STORAGE_REPO_TAG=v{{ nebula.release }} ..
+      ```
 
 5. 编译Nebula Graph。
 
-    为了适当地加快编译速度，可以使用选项`-j`并行编译。并行数量`N`建议为$min(CPU核数,\frac{内存(GB)}{2})$。
+   为了适当地加快编译速度，可以使用选项`-j`并行编译。并行数量`N`建议为$min(CPU核数,\frac{内存(GB)}{2})$。
 
-    ```bash
-    $ make -j{N}
-    ```
+   ```bash
+   $ make -j{N}
+   ```
+
 6. 安装Nebula Graph。
 
-    ```bash
-    $ sudo make install-all
-    ```
+   ```bash
+   $ sudo make install-all
+   ```
 
 7. （可选）更新`master`分支的源码，因为它经常更新。
 
-    1. 在目录`nebula-graph/`中，执行命令`git pull upstream master`更新源码。
+   1. 在目录`nebula-graph/`中，执行命令`git pull upstream master`更新源码。
 
-    2. 在目录`nebula-graph/modules/common/`和`nebula-graph/modules/storage/`中，分别执行命令`git pull upstream master`。
+   2. 在目录`nebula-graph/modules/common/`和`nebula-graph/modules/storage/`中，分别执行命令`git pull upstream master`。
 
-    3. 在目录`nebula-graph/build/`中，重新执行`make -j{N}`和`make install-all`。
+   3. 在目录`nebula-graph/build/`中，重新执行`make -j{N}`和`make install-all`。
 
 ## 下一步
 
@@ -123,19 +124,19 @@ $ cmake -D<variable>=<value> ...
 
 - `Debug`
 
-    `MAKE_BUILD_TYPE`的默认值，build过程中只记录debug信息，不使用优化选项。
+   `MAKE_BUILD_TYPE`的默认值，build过程中只记录debug信息，不使用优化选项。
 
 - `Release`
 
-    build过程中使用优化选项，不记录debug信息。
+   build过程中使用优化选项，不记录debug信息。
 
 - `RelWithDebInfo`
 
-    build过程中既使用优化选项，也记录debug信息。
+   build过程中既使用优化选项，也记录debug信息。
 
 - `MinSizeRel`
 
-    build过程中仅通过优化选项控制代码大小，不记录debug信息。
+   build过程中仅通过优化选项控制代码大小，不记录debug信息。
 
 ### CMAKE_C_COMPILER/CMAKE_CXX_COMPILER
 

--- a/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
+++ b/docs-2.0/4.deployment-and-installation/2.compile-and-install-nebula-graph/1.install-nebula-graph-by-compiling-the-source-code.md
@@ -14,15 +14,15 @@
 
     - 如果需要安装最新版本的开发代码，请执行如下命令下载`master`分支的源码：
 
-        ```bash
-        $ git clone https://github.com/vesoft-inc/nebula-graph.git
-        ```
+    ```bash
+    $ git clone https://github.com/vesoft-inc/nebula-graph.git
+    ```
 
     - 如果需要安装指定版本的Nebula Graph 2.x，请使用选项`--branch`指定分支。例如安装{{ nebula.release }} 发布版本，请执行如下命令：
 
-        ```bash
-        $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-graph.git
-        ```
+    ```bash
+    $ git clone --branch v{{ nebula.release }} https://github.com/vesoft-inc/nebula-graph.git
+    ```
 
 2. 进入目录`nebula-graph`。
 
@@ -45,16 +45,16 @@
 
     - 如果您在第1步下载的是最新版本的开发代码，请执行如下命令：
 
-        ```bash
-        $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
-        ```
+    ```bash
+    $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release ..
+    ```
 
     - 如果您在第1步下载的是指定版本的Nebula Graph 2.x，请使用选项`-DNEBULA_COMMON_REPO_TAG`和`-DNEBULA_STORAGE_REPO_TAG`指定相同的[nebula-common](https://github.com/vesoft-inc/nebula-common)和[nebula-storage](https://github.com/vesoft-inc/nebula-storage)分支。例如安装{{ nebula.release }} GA版本，请执行如下命令：
 
-        ```bash
-        $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
-        -DNEBULA_COMMON_REPO_TAG=v{{ nebula.release }} -DNEBULA_STORAGE_REPO_TAG=v{{ nebula.release }} ..
-        ```
+    ```bash
+    $ cmake -DENABLE_BUILD_STORAGE=on -DENABLE_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
+    -DNEBULA_COMMON_REPO_TAG=v{{ nebula.release }} -DNEBULA_STORAGE_REPO_TAG=v{{ nebula.release }} ..
+    ```
 
 5. 编译Nebula Graph。
 


### PR DESCRIPTION
For the reason indentation itself is the semantics
of the basic code block [0], thus the backticks fenced
code blocks [1] will end up being escaped [2].

[0] https://www.markdownguide.org/basic-syntax#code-blocks
[1] https://www.markdownguide.org/extended-syntax/#fenced-code-blocks
[2] https://docs.nebula-graph.com.cn/2.0.1/4.deployment-and-installation/1.resource-preparations/

Could you please help see if it's the way to fix this(sorry, I didn't try to render it via `mkdocs` yet)?