### PR TITLE
Remove search lang settings

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -379,10 +379,7 @@ markdown_extensions:
 
 # Plugins
 plugins:
-  - search:
-      lang:
-        - jp
-        - en
+  - search
   - macros
   - git-revision-date-localized
   - with-pdf:


### PR DESCRIPTION
Mkdocs [documentation](https://www.mkdocs.org/user-guide/configuration/#lang) mentioned that we can use lang: jp for Chinese searching. But it failed and has disabled the search function entirely. 

Remove the settings to roll back.