### PR TITLE
Fix the description of collation

### DIFF
--- a/docs-2.0/3.ngql-guide/7.general-query-statements/6.show/2.show-collation.md
+++ b/docs-2.0/3.ngql-guide/7.general-query-statements/6.show/2.show-collation.md
@@ -8,7 +8,7 @@
 
 - 当字符集为`utf8mb4`，默认排序规则为`utf8mb4_bin`。
 
-- `utf8mb4_bin`和`utf8mb4_general_ci`不区分大小写。
+- `utf8_general_ci`和`utf8mb4_general_ci`不区分大小写。
 
 ## 语法
 


### PR DESCRIPTION
I think it is a typo in the Chinese version.
In the English version [SHOW COLLATION](https://docs.nebula-graph.io/2.0.1/3.ngql-guide/7.general-query-statements/6.show/2.show-collation/)
> Both utf8_general_ci and utf8mb4_general_ci are case-insensitive.