### PR TITLE
the rendered layout for "sysctl" section is incorrect

### DIFF
--- a/docs-2.0/5.configurations-and-logs/1.configurations/6.kernel-config.md
+++ b/docs-2.0/5.configurations-and-logs/1.configurations/6.kernel-config.md
@@ -100,11 +100,16 @@ TCP套接字发送/接收缓冲池的最小、最大、默认空间。对于大�
 ### sysctl命令
 
 - `sysctl <conf_name>` 
-查看当前参数值。
+
+  查看当前参数值。
+
 - `sysctl -w <conf_name>=<value>` 
-临时修改参数值，立即生效，重启后恢复原值。
+
+  临时修改参数值，立即生效，重启后恢复原值。
+
 - `sysctl -p [<file_path>]` 
-从指定配置文件里加载Linux系统参数，默认从`/etc/sysctl.conf`加载。
+
+  从指定配置文件里加载Linux系统参数，默认从`/etc/sysctl.conf`加载。
 
 ### prlimit
 


### PR DESCRIPTION
sysctl命令和相应的说明部分多了回车导致render出来的layout不对，在中文doc的2.5/2.0.1版本中已经相应的PDF中都发现这个问题。