### PR TITLE
fixed create index comment syntax

### DIFF
--- a/docs-2.0/3.ngql-guide/14.native-index-statements/1.create-native-index.md
+++ b/docs-2.0/3.ngql-guide/14.native-index-statements/1.create-native-index.md
@@ -63,7 +63,7 @@
 ## 语法
 
 ```ngql
-CREATE {TAG | EDGE} INDEX [IF NOT EXISTS] <index_name> ON {<tag_name> | <edge_name>} ([<prop_name_list>]) [COMMENT = '<comment>'];
+CREATE {TAG | EDGE} INDEX [IF NOT EXISTS] <index_name> ON {<tag_name> | <edge_name>} ([<prop_name_list>]) [COMMENT '<comment>'];
 ```
 
 |参数|说明|


### PR DESCRIPTION
ref: https://github.com/vesoft-inc/nebula/issues/3945


```sql
(root@nebula) [basketballplayer]> create tag index player_index_age on player(age) comment "age index"
Execution succeeded (time spent 4415/10141 us)

Fri, 25 Feb 2022 19:08:53 CST

(root@nebula) [basketballplayer]> create tag index player_index_age on player(age) comment = "age index"
[ERROR (-1004)]: SyntaxError: syntax error near `= "age i'

Fri, 25 Feb 2022 19:10:53 CST
```