### PR TITLE
Optimize MATCH doc

### DIFF
--- a/docs-2.0/3.ngql-guide/7.general-query-statements/2.match.md
+++ b/docs-2.0/3.ngql-guide/7.general-query-statements/2.match.md
@@ -36,7 +36,7 @@ MATCH <pattern> [<clause_1>]  RETURN <output>  [<clause_2>];
 
 !!! note
 
-    目前 match 语句无法查询到悬挂边。
+    目前 MATCH 语句无法查询到悬挂边。
 
 !!! compatibility "历史版本兼容性" 
 
@@ -115,7 +115,7 @@ nebula> MATCH (v) \
 
 !!! Compatibility "历史版本兼容性"
 
-    在 Nebula Graph 3.0.0 之前，匹配 Tag 的前提是  Tag 本身有索引或者 Tag 的某个属性有索引，否则，用户无法基于该 Tag 执行 `MATCH` 语句。从 Nebula Graph 3.0.0 开始，匹配 Tag 可以不创建索引，但需要使用 `LIMIT` 限制输出结果数量。
+    在 Nebula Graph 3.0.0 之前，匹配 Tag 的前提是 Tag 本身有索引或者 Tag 的某个属性有索引，否则，用户无法基于该 Tag 执行 `MATCH` 语句。从 Nebula Graph 3.0.0 开始，匹配 Tag 可以不创建索引，但需要使用 `LIMIT` 限制输出结果数量。
 
 用户可以在点的右侧用`:<tag_name>`表示模式中的 Tag。
 
@@ -149,10 +149,6 @@ nebula> MATCH (v:player:actor) \
 ```
 
 ### 匹配点的属性
-
-!!! Note
-
-    匹配点的属性的前提是 Tag 本身有对应属性的索引，否则，用户无法执行 `MATCH` 语句匹配该属性。
 
 用户可以在 Tag 的右侧用`{<prop_name>: <prop_value>}`表示模式中点的属性。
 
@@ -440,10 +436,6 @@ nebula> MATCH (v:player{name:"Tim Duncan"}) -[*0]-> (v2) \
 
 用户可以在模式中使用`:<edge_type>*[minHop..maxHop]`匹配变长路径。
 
-!!! note
-
-    设置边界时，`minHop` 和 `maxHop` 至少存在其中一个。
-
 !!! caution
 
     如果未设置 `maxHop` 可能会导致 graph 服务 OOM，请谨慎执行该命令。
@@ -452,6 +444,8 @@ nebula> MATCH (v:player{name:"Tim Duncan"}) -[*0]-> (v2) \
 |:---|:---|
 |`minHop`|可选项。表示路径的最小长度。`minHop`必须是一个非负整数，默认值为 1。|
 |`maxHop`|可选项。表示路径的最大长度。`maxHop`必须是一个非负整数，默认值为无穷大。|
+
+如果未指定`minHop`和`maxHop`，仅设置了`:<edge_type>*`，则二者都应用默认值，即`minHop`为 1，`maxHop`为无穷大。
 
 ```ngql
 nebula> MATCH p=(v:player{name:"Tim Duncan"})-[e:follow*]->(v2) \
@@ -500,7 +494,7 @@ nebula> MATCH p=(v:player{name:"Tim Duncan"})-[e:follow*1..3]->(v2:player) \
 +-----------------------------------------------------------+-----------+
 ```
 
-如果`minHop`为`0`，模式会匹配路径上的起始点。与上个示例相比，下面的示例设置`minHop`为`0`，因为它是起始点，所以结果集中`"Tim Duncan"`比上个示例多计算一次。
+如果`minHop`为`0`，模式会匹配路径上的起始点。例如，与上个示例相比，下面的示例设置`minHop`为`0`。此时，因为表示`"Tim Duncan"`的点是路径的起始点，所以它在结果集中的计数为 5，比在上个示例的结果中多计一次。
 
 ```ngql
 nebula> MATCH p=(v:player{name:"Tim Duncan"})-[e:follow*0..3]->(v2:player) \


### PR DESCRIPTION
- Deleted deprecated notes.
- Optimized expressions.
- Added instruction for keeping `minHop` and `maxHop` as default.