### PR TITLE
correct 1.create-tag.md TTL_DURATION

### DIFF
--- a/docs-2.0/3.ngql-guide/10.tag-statements/1.create-tag.md
+++ b/docs-2.0/3.ngql-guide/10.tag-statements/1.create-tag.md
@@ -37,7 +37,7 @@ CREATE TAG [IF NOT EXISTS] <tag_name>
 |`NULL \| NOT NULL`|指定属性值是否支持为`NULL`。默认值为`NULL`。|
 |`DEFAULT`|指定属性的默认值。默认值可以是一个文字值或 Nebula Graph 支持的表达式。如果插入点时没有指定某个属性的值，则使用默认值。|
 |`COMMENT`|对单个属性或 Tag 的描述。最大为 256 字节。默认无描述。|
-|`TTL_DURATION`|指定属性存活时间。超时的属性将会过期。属性值和时间戳差值之和如果小于当前时间戳，属性就会过期。默认值为`0`，表示属性永不过期。|
+|`TTL_DURATION`|指定属性存活时间。超时的属性将会过期。属性值和属性存活时间之和如果小于当前时间戳，属性就会过期。默认值为`0`，表示属性永不过期。|
 |`TTL_COL`|指定要设置存活时间的属性。属性的数据类型必须是`int`或者`timestamp`。一个 Tag 只能指定一个字段为`TTL_COL`。更多 TTL 的信息请参见 [TTL](../8.clauses-and-options/ttl-options.md)。|
 
 ## 示例

--- a/docs-2.0/3.ngql-guide/10.tag-statements/1.create-tag.md
+++ b/docs-2.0/3.ngql-guide/10.tag-statements/1.create-tag.md
@@ -37,7 +37,7 @@ CREATE TAG [IF NOT EXISTS] <tag_name>
 |`NULL \| NOT NULL`|指定属性值是否支持为`NULL`。默认值为`NULL`。|
 |`DEFAULT`|指定属性的默认值。默认值可以是一个文字值或 Nebula Graph 支持的表达式。如果插入点时没有指定某个属性的值，则使用默认值。|
 |`COMMENT`|对单个属性或 Tag 的描述。最大为 256 字节。默认无描述。|
-|`TTL_DURATION`|指定属性存活时间。超时的属性将会过期。属性值和属性存活时间之和如果小于当前时间戳，属性就会过期。默认值为`0`，表示属性永不过期。|
+|`TTL_DURATION`|指定时间戳差值，单位：秒。时间戳差值必须为 64 位非负整数。属性值和时间戳差值之和如果小于当前时间戳，属性就会过期。默认值为`0`，表示属性永不过期。|
 |`TTL_COL`|指定要设置存活时间的属性。属性的数据类型必须是`int`或者`timestamp`。一个 Tag 只能指定一个字段为`TTL_COL`。更多 TTL 的信息请参见 [TTL](../8.clauses-and-options/ttl-options.md)。|
 
 ## 示例


### PR DESCRIPTION
https://docs.nebula-graph.com.cn/3.1.0/3.ngql-guide/10.tag-statements/1.create-tag/
中关于TTL_DURATION的描述是：“指定属性存活时间。超时的属性将会过期。属性值和时间戳差值之和如果小于当前时间戳，属性就会过期。默认值为0，表示属性永不过期。”
1、官方文档中“属性值和时间戳差值之和如果小于当前时间戳，属性就会过期”这句话转为公式就是：prop+(current-prop)<current 等价于 0 < 0时，属性就会过期。
2、然而，过期代表的含义应当是：prop+TTL_DURATION<current就会过期。
1和2的公式是不等价的，所以正确的表述应当是：属性值和属性存活时间之和如果小于当前时间戳，属性就会过期。