### PR TITLE
Add GO OVER wildcard edge type example

### DIFF
--- a/docs-2.0/3.ngql-guide/7.general-query-statements/3.go.md
+++ b/docs-2.0/3.ngql-guide/7.general-query-statements/3.go.md
@@ -228,3 +228,15 @@ nebula> GO FROM "player100" OVER follow WHERE properties($$).name IS NOT EMPTY Y
 | "player101" |
 +-------------+
 ```
+
+```ngql
+# 用 * 表示所有边类型。
+nebula> GO FROM "player100" OVER * YIELD dst(edge);
++-------------+
+| dst(EDGE)   |
++-------------+
+| "player125" |
+| "player101" |
+| "team204"   |
++-------------+
+```


### PR DESCRIPTION
as titled, fresh user may not understand how * could be used without examples.