### PR TITLE
feat: add conditional rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -79,6 +79,7 @@ plugins:
         - spark-connector/*
         - 4.deployment-and-installation/5.zone.md
         - 4.deployment-and-installation/3.upgrade-nebula-graph/upgrade-nebula-from-200-to-latest.md
+
         # 仅发布包含企业版功能的文档版本时，注释以下页面
         # begin
 #       - 3.ngql-guide/6.functions-and-expressions/17.ES-function.md
@@ -95,7 +96,8 @@ plugins:
 #       - nebula-dashboard-ent/4.cluster-operator/operator/scale.md
 #       - 6.monitor-and-metrics/3.bbox
         # end
-        
+        # comm.begin
+        # comm.end
 
 # Exclude the file with the following file name.
 #        - abc.md
@@ -125,6 +127,10 @@ extra_javascript:
 
 # modify when release: 
 extra:
+  # For conditional rendering
+  # Valid options: enterprise, community, both
+  # enterprise means this version is for the Enterprise only. And so on in a similar fashion
+  database_edition: community
   # Language selector.
   alternate:
     - name: English

--- a/prepare.sh
+++ b/prepare.sh
@@ -1,9 +1,13 @@
 sudo apt update -y
 sudo apt install -y python3-pip python3-cffi python3-brotli libpango-1.0-0 libharfbuzz0b libpangoft2-1.0-0 pango1.0-tools 
 
-
+# Install dependencies
 pip install --upgrade pip
 pip install -r ./requirements.txt
+
+# Render content according to the database_edition in mkdocs.yml
+python ./scripts/conditional_render.py
+python ./scripts/conditional_yml.py
 
 # zh language
 sudo apt install font-manager fonts-noto-cjk language-pack-zh-hans fonts-arphic-ukai fonts-arphic-uming fonts-ipafont-mincho fonts-ipafont-gothic fonts-unfonts-core

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ mkdocs-exclude
 mkdocs-redirects
 mkdocs-minify-plugin
 Markdown==3.3.7
+pyyaml

--- a/scripts/conditional_render.py
+++ b/scripts/conditional_render.py
@@ -1,0 +1,40 @@
+# Rules for processing the markdown files in the docs-2.0 directory:
+# - If database_edition is enterprise, the content between {{ ent.ent_begin }} and {{ ent.ent_end }} is kept and the content between {{ comm.comm_begin }} and {{ comm.comm_end }} is removed. 
+# - If database_edition is community, the content between {{ comm.comm_begin }} and {{ comm.comm_end }} is kept and the content between {{ ent.ent_begin }} and {{ ent.ent_end }} is removed. 
+# - If database_edition is both, both types of content are removed.
+
+import os
+import re
+import yaml
+
+def process_files(file_path, database_edition):
+    for root, dirs, files in os.walk(file_path):
+        for file in files:
+            if file.endswith('.md'):
+                file_full_path = os.path.join(root, file)
+                with open(file_full_path, 'r', encoding='utf-8') as f:
+                    content = f.read()
+                if database_edition == 'enterprise':
+                    content = re.sub(
+                        r'{{\s*ent\.ent_begin\s*}}(.*?){{\s*ent\.ent_end\s*}}', 
+                        '\\1', content, flags=re.DOTALL)
+                    content = re.sub(
+                        r'{{\s*comm\.comm_begin\s*}}(.*?){{\s*comm\.comm_end\s*}}', 
+                        '', content, flags=re.DOTALL)
+                elif database_edition == 'community':
+                    content = re.sub(
+                        r'{{\s*ent\.ent_begin\s*}}(.*?){{\s*ent\.ent_end\s*}}', 
+                        '', content, flags=re.DOTALL)
+                    content = re.sub(
+                        r'{{\s*comm\.comm_begin\s*}}(.*?){{\s*comm\.comm_end\s*}}', 
+                        '\\1', content, flags=re.DOTALL)
+                with open(file_full_path, 'w', encoding='utf-8') as f:
+                    f.write(content)
+
+if __name__ == '__main__':
+    mkdocs_yml_path = 'mkdocs.yml'
+    with open(mkdocs_yml_path, 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    database_edition = config.get("extra", {}).get("database_edition", "both")
+    file_path = 'docs-2.0/'
+    process_files(file_path, database_edition)

--- a/scripts/conditional_render.py
+++ b/scripts/conditional_render.py
@@ -36,5 +36,7 @@ if __name__ == '__main__':
     with open(mkdocs_yml_path, 'r', encoding='utf-8') as f:
         config = yaml.safe_load(f)
     database_edition = config.get("extra", {}).get("database_edition", "both")
+    if database_edition not in ['community', 'enterprise', 'both']:
+        raise ValueError("Invalid value for database_edition: {}".format(database_edition))
     file_path = 'docs-2.0/'
     process_files(file_path, database_edition)

--- a/scripts/conditional_render.py
+++ b/scripts/conditional_render.py
@@ -1,7 +1,7 @@
 # Rules for processing the markdown files in the docs-2.0 directory:
 # - If database_edition is enterprise, the content between {{ ent.ent_begin }} and {{ ent.ent_end }} is kept and the content between {{ comm.comm_begin }} and {{ comm.comm_end }} is removed. 
 # - If database_edition is community, the content between {{ comm.comm_begin }} and {{ comm.comm_end }} is kept and the content between {{ ent.ent_begin }} and {{ ent.ent_end }} is removed. 
-# - If database_edition is both, both types of content are removed.
+# - If database_edition is both, both types of content are kept.
 
 import os
 import re

--- a/scripts/conditional_yml.py
+++ b/scripts/conditional_yml.py
@@ -1,0 +1,45 @@
+# Rules for processing the mkdocs.yml file:
+# - When `database_edition` is `community`, keep all content between tags `# ent.begin` and `# ent.end`, and delete all content between tags `# comm.begin` and `# comm.end`.
+# - When `database_edition` is `enterprise`, keep all content between `# comm.begin` and `# comm.end`, and delete all content between `# ent.begin` and `# ent.end`
+# - When `database_edition` is `both`, delete all content between `# ent.begin` and `# ent.end`, and between `# comm.begin` and `# comm.end`.
+# - Always keep the tags.
+
+import os
+import re
+import yaml
+
+mkdocs_yml_path = 'mkdocs.yml'
+
+def process_mkdocs_yml(mkdocs_yml_path, database_edition):
+    with open(mkdocs_yml_path, 'r', encoding='utf-8') as f:
+        content = f.read()
+    if database_edition == 'enterprise':
+        content = re.sub(
+            r'#\s*ent\.begin(.*?)#\s*ent\.end', 
+            '', content, flags=re.DOTALL)
+        content = re.sub(
+            r'#\s*comm\.begin(.*?)#\s*comm\.end', 
+            '\\1', content, flags=re.DOTALL)
+    elif database_edition == 'community':
+        content = re.sub(
+            r'#\s*ent\.begin(.*?)#\s*ent\.end', 
+            '\\1', content, flags=re.DOTALL)
+        content = re.sub(
+            r'#\s*comm\.begin(.*?)#\s*comm\.end', 
+            '', content, flags=re.DOTALL)
+    elif database_edition == 'both':
+        content = re.sub(
+            r'#\s*ent\.begin(.*?)#\s*ent\.end', 
+            '', content, flags=re.DOTALL)
+        content = re.sub(
+            r'#\s*comm\.begin(.*?)#\s*comm\.end', 
+            '', content, flags=re.DOTALL)
+    with open(mkdocs_yml_path, 'w', encoding='utf-8') as f:
+        f.write(content)
+
+if __name__ == '__main__':
+    mkdocs_yml_path = 'mkdocs.yml'
+    with open(mkdocs_yml_path, 'r', encoding='utf-8') as f:
+        config = yaml.safe_load(f)
+    database_edition = config.get("extra", {}).get("database_edition", "both")
+    process_mkdocs_yml(mkdocs_yml_path, database_edition)

--- a/scripts/conditional_yml.py
+++ b/scripts/conditional_yml.py
@@ -42,4 +42,6 @@ if __name__ == '__main__':
     with open(mkdocs_yml_path, 'r', encoding='utf-8') as f:
         config = yaml.safe_load(f)
     database_edition = config.get("extra", {}).get("database_edition", "both")
+    if database_edition not in ['community', 'enterprise', 'both']:
+        raise ValueError("Invalid value for database_edition: {}".format(database_edition))
     process_mkdocs_yml(mkdocs_yml_path, database_edition)


### PR DESCRIPTION
Render content according to the database_edition in mkdocs.yml.
Added two scripts to process markdown files and the mkdocs.yml separately.

Rules for processing the mkdocs.yml file (here keeping something means hiding it with the exclude plugin, while deleting something means releasing it):
- When `database_edition` is `community`, keep all content between tags `# ent.begin` and `# ent.end`, and delete all content between tags `# comm.begin` and `# comm.end`.
- When `database_edition` is `enterprise`, keep all content between `# comm.begin` and `# comm.end`, and delete all content between `# ent.begin` and `# ent.end`
- When `database_edition` is `both`, delete all content between `# ent.begin` and `# ent.end`, and between `# comm.begin` and `# comm.end`.
- Always keep the tags.

Rules for processing the markdown files in the docs-2.0 directory (here deleting something means don't show it, and keeping means show it):
- If `database_edition` is `enterprise`, the content between `{{ ent.ent_begin }}` and `{{ ent.ent_end }}` is kept and the content between `{{ comm.comm_begin }}` and `{{ comm.comm_end }}` is removed. 
- If database_edition is community, the content between `{{ comm.comm_begin }}` and `{{ comm.comm_end }}` is kept and the content between `{{ ent.ent_begin }}` and `{{ ent.ent_end }}` is removed. 
- If `database_edition` is `both`, both types of content are kept.
- Deletes all the tags once the script is run.

The scripts are run in the prepare.sh script before building the docs.

REMEMBER: Write enterprise-only content between `{{ ent.ent_begin }}` and `{{ ent.ent_end }}` in markdown files, and community-only content between `{{ comm.comm_begin }}` and `{{ comm.comm_end }}`.