### PR TITLE
Fixed the order of doc versions deploy.yaml

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -107,6 +107,7 @@ jobs:
                 break
           if not found:
               json_data.append(new_content)
+          json_data = sorted(json_data, key=lambda x: x['version'], reverse=True)
           with open('./versions.json', 'w') as outfile:
               json.dump(json_data, outfile, indent=2)
         shell: python        


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

The new order will be like:

```python
[{'version': 'master', 'title': 'master', 'aliases': []},
 {'version': '3.5.0', 'title': 'v3.5.0', 'aliases': []},
 {'version': '3.4.1', 'title': '3.4.1', 'aliases': []},
 {'version': '3.3.0', 'title': '3.3.0', 'aliases': []},
 {'version': '3.2.1', 'title': '3.2.1', 'aliases': []},
 {'version': '3.1.3', 'title': '3.1.3', 'aliases': []},
 {'version': '3.0.2', 'title': '3.0.2', 'aliases': []},
 {'version': '2.6.2', 'title': '2.6.2', 'aliases': []}]
```


