### PR TITLE
Remove Polyfill and fix v3.4.3 publish workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,15 +8,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1 # fetch all commits/branches 
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10.17'
+          python-version: '3.10'
           architecture: 'x64'
+          cache: 'pip'
 
       - name : prepare
         run: sh ./prepare.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,7 +122,6 @@ extra_javascript:
   - js/config.js
   - js/jquery.js
   - js/init.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
   # js about docs search logic
   - https://www-cdn.nebula-graph.com.cn/nebula-docs/nebula-docs.7e772ed81c779cacbefc.js

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 mkdocs
 weasyprint==54.3
+pydyf==0.1.2
 mkdocs-material-extensions
 mike==1.1.2
 mkdocs-material==9.4.6


### PR DESCRIPTION
Remove the external Polyfill script and modernize the legacy publish workflow.

- Remove the polyfill.io JavaScript entry.
- Upgrade checkout and setup-python actions to v6.
- Use Ubuntu latest and Python 3.10 with pip caching.
- Pin pydyf to the version compatible with the legacy WeasyPrint release.