### PR TITLE
Remove Polyfill and fix v3.1.3 publish workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: mike 
         run: |
           git fetch origin gh-pages --depth=1 # fix mike's CI update
-          mike deploy 3.1.3 -p --rebase
+          mike deploy 3.1.3 -p
           mike list
 
       - name: show git branch

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -8,15 +8,16 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1 # fetch all commits/branches
 
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.8'
+          python-version: '3.10'
           architecture: 'x64'
+          cache: 'pip'
 
       - name : prepare
         run: sh ./prepare.sh

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,6 @@ extra_javascript:
   - js/config.js
   - js/jquery.js
   - js/init.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 # modify when release:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,14 +1,15 @@
 Markdown==3.3.7
 mkdocs==1.3.0
 weasyprint==54.3
+pydyf==0.1.2
 mkdocs-material-extensions
 mike
 mkdocs-material
 mkdocs-material-extensions
-mkdocs-macros-plugin
+mkdocs-macros-plugin==1.4.0
 mdx_truly_sane_lists
 mkdocs_latest_release_plugin
-mkdocs-git-revision-date-localized-plugin
+mkdocs-git-revision-date-localized-plugin==1.3.0
 mkdocs-with-pdf
 qrcode
 mkdocs-exclude

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ mkdocs==1.3.0
 weasyprint==54.3
 pydyf==0.1.2
 mkdocs-material-extensions
-mike
+mike==2.2.0
 mkdocs-material
 mkdocs-material-extensions
 mkdocs-macros-plugin==1.4.0


### PR DESCRIPTION
Remove the external Polyfill script and modernize the legacy publish workflow.

- Remove the polyfill.io JavaScript entry.
- Upgrade checkout and setup-python actions to v6.
- Use Ubuntu latest and Python 3.10 with pip caching.
- Pin pydyf and MkDocs plugins to versions compatible with the legacy MkDocs/WeasyPrint releases.