### PR TITLE
Fix Mike deployment for v3.0.1

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
         run: |
           mike list
           # mike delete v3.0.1 -p
-          mike deploy 3.0.1 -p --rebase
+          mike deploy 3.0.1 -p
           mike list
 
       - name: show git branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ mkdocs==1.3.0
 weasyprint==54.3
 pydyf==0.1.2
 mkdocs-material-extensions
-mike
+mike==2.2.0
 mkdocs-material
 mkdocs-material-extensions
 mkdocs-macros-plugin==1.4.0


### PR DESCRIPTION
## Summary
- pin Mike to 2.2.0 to make CI dependency resolution reproducible
- remove the obsolete `--rebase` option, which was removed in Mike 2.0

## Validation
- parsed `.github/workflows/deploy.yaml` with PyYAML
- ran `git diff --check`
- verified the deploy command no longer contains `--rebase`