### PR TITLE
fix: make v3.6.0 publish workflow compatible with Mike 2.2

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -84,10 +84,21 @@ jobs:
           python ./scripts/conditional_render.py
           python ./scripts/conditional_yml.py
           python ./scripts/conditional_pdf.py
-          git fetch origin gh-pages
-          mike --rebase deploy ${{ env.ACTIONTEST }} -p
-          mike --rebase set-default ${{ env.ACTIONTEST }} -p
-          mike list
+          for attempt in 1 2 3; do
+            git fetch origin gh-pages
+            git branch -f gh-pages origin/gh-pages
+
+            if mike deploy ${{ env.ACTIONTEST }} -p && mike set-default ${{ env.ACTIONTEST }} -p; then
+              mike list
+              exit 0
+            fi
+
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+
+            sleep $((attempt * 30))
+          done
       - name: show git branch
         run: | 
           git branch

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 mkdocs==1.3.0
 weasyprint==54.3
+pydyf==0.1.2
 mkdocs-material-extensions
-mike
+mike==2.2.0
 mkdocs-material
 mkdocs-material-extensions
 mkdocs-macros-plugin


### PR DESCRIPTION
## Summary
- pin `mike==2.2.0` and remove the unsupported `--rebase` option from `deploy` and `set-default`
- reset the local `gh-pages` branch to the latest remote state before every attempt
- retry the complete deployment up to three times after concurrent push failures
- pin `pydyf==0.1.2` for WeasyPrint 54.3 compatibility

## Validation
- workflow YAML parsed successfully
- deployment shell loop passed `bash -n`
- Mike 2.2.0 CLI help confirms that `--rebase` is no longer supported